### PR TITLE
Removed upper dependency bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     author='Ioan Alexandru Cucu',
     author_email='alexandruioan.cucu@gmail.com',
     url='https://github.com/kux/django-admin-extend',
-    install_requires=('Django>=1.3,<=1.5.4',),
+    install_requires=('Django>=1.3',),
     packages=find_packages(),
     include_package_data=True,
 )


### PR DESCRIPTION
Installing django-admin-extend via pip when using Django 1.5.5 forcibly downgrades Django to 1.5.4.
Could we either remove the <=1.5.4 bound in setup.py or raise it to <=1.5.5?
